### PR TITLE
Replace Cell<u64> with AtomicU64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target/
+/Cargo.lock

--- a/src/search.rs
+++ b/src/search.rs
@@ -17,6 +17,7 @@ use ucioption;
 use std;
 use std::io::stdout;
 use std::io::Write;
+use std::sync::atomic::Ordering;
 use std::time::Instant;
 
 pub const CM_THRESHOLD: i32 = 0;
@@ -1763,8 +1764,8 @@ fn update_stats(
 
 fn update_counters(pos: &Position) {
     let th = pos.thread_ctrl.as_ref().unwrap();
-    th.nodes.set(pos.nodes);
-    th.tb_hits.set(pos.tb_hits);
+    th.nodes.store(pos.nodes, Ordering::Release);
+    th.tb_hits.store(pos.tb_hits, Ordering::Release);
 }
 
 // check_time() is used to print debug info and, more importantly, to detect

--- a/src/threads.rs
+++ b/src/threads.rs
@@ -10,7 +10,6 @@ use types::*;
 use ucioption;
 
 use std;
-use std::cell::Cell;
 use std::sync::{Arc, Condvar, Mutex, RwLock};
 use std::sync::atomic::*;
 use std::sync::mpsc::*;
@@ -44,9 +43,8 @@ pub struct ThreadCtrl {
     pub state: Mutex<ThreadState>,
     pub common: Mutex<CommonState>,
     pub cv: Condvar,
-    // nodes and tb_hits are Cell<u64> for lack of atomic u64 types
-    pub nodes: Cell<u64>,
-    pub tb_hits: Cell<u64>,
+    pub nodes: AtomicU64,
+    pub tb_hits: AtomicU64,
 }
 
 impl ThreadCtrl {
@@ -71,15 +69,12 @@ impl ThreadCtrl {
                 })),
             }),
             cv: Condvar::new(),
-            nodes: Cell::new(0),
-            tb_hits: Cell::new(0),
+            nodes: AtomicU64::new(0),
+            tb_hits: AtomicU64::new(0),
         };
         thread_ctrl
     }
 }
-
-// Remove next line when nodes and tb_hits can be made atomic u64
-unsafe impl Sync for ThreadCtrl { }
 
 type Handlers = Vec<thread::JoinHandle<()>>;
 type Threads = Vec<Arc<ThreadCtrl>>;
@@ -351,8 +346,8 @@ pub fn start_thinking(
     }));
 
     for th in threads.iter() {
-        th.nodes.set(0);
-        th.tb_hits.set(0);
+        th.nodes.store(0, Ordering::Release);
+        th.tb_hits.store(0, Ordering::Release);
         let mut common = th.common.lock().unwrap();
         common.root_moves = root_moves.clone();
         common.pos_data = pos_data.clone();
@@ -370,7 +365,7 @@ pub fn nodes_searched() -> u64 {
     let mut nodes = 0;
 
     for th in threads.iter() {
-        nodes += th.nodes.get();
+        nodes += th.nodes.load(Ordering::Acquire);
     }
 
     std::mem::forget(threads);
@@ -384,7 +379,7 @@ pub fn tb_hits() -> u64 {
     let mut tb_hits = 0;
 
     for th in threads.iter() {
-        tb_hits += th.tb_hits.get();
+        tb_hits += th.tb_hits.load(Ordering::Acquire);
     }
 
     std::mem::forget(threads);


### PR DESCRIPTION
Replaces Cell with atomic usage, removes unsafe impl.